### PR TITLE
Reorganize CFP text for track 3

### DIFF
--- a/templates/content/call-for-papers-track-3.md
+++ b/templates/content/call-for-papers-track-3.md
@@ -6,23 +6,7 @@
 ### Description
 Algorithms do not exist in the digital world alone: indeed, they often explicitly take aim at important social outcomes. This track considers issues at the intersection of algorithms and the societies they seek to impact, specifically with respect to health. Submissions could include methodological contributions such as algorithmic development and performance evaluation for policy and public health applications, combining clinical and non-clinical data, as well as detecting and measuring bias. Submissions could also include impact-oriented research such as determining how algorithmic systems for health may introduce, exacerbate, or reduce inequities and inequalities, discrimination, and unjust outcomes, as well as evaluating the economic implications of these systems. Submissions related to understanding barriers to deployment and adoption of algorithmic systems for societal-level health applications are also of interest. In addressing these problems, insights from social sciences, law, clinical medicine, and the humanities can be crucial.
 
-We welcome papers from various areas of interest (see list below) and at least one sub-discipline upon abstract registration. 
-
-<!-- ### Areas of interest
-- Fairness, equity, ethics and justice
-- Model implementation, deployment, and adoption
-- Policy, public health, and societal impact of algorithms
-- Interpretability
-- System design for implementation of ML at scale
-- Regulatory frameworks
-- Tools for adoption of ML
-- Evaluation of bias in legal and/or health contexts
-- Human-algorithm interaction -->
-
-**Examples**
-All areas of machine learning influencing policy and society are amenable to this track. An example set of topics of interest and exemplar papers are shown below. These examples are by no means exhaustive and are meant as illustration and motivation.
-
-Some particular areas of interest are:
+We welcome papers from various areas of interest, and at least one sub-discipline upon abstract registration, such as:
 
 - Fairness, equity, ethics and justice
 - Model implementation, deployment, and adoption
@@ -34,6 +18,9 @@ Some particular areas of interest are:
 - Evaluation of bias in legal and/or health contexts
 - Human-algorithm interaction
 
+### Examples
+
+All areas of machine learning influencing policy and society are amenable to this track. Exemplar papers are shown below. These examples are by no means exhaustive and are meant as illustration and motivation.
 
 Bolukbasi T, Chang K-W, Zou J, Saligrama V, Kalai A. 2016. Quantifying and reducing stereotypes in word embeddings. arXiv:1606.06121 [cs.CL]
 


### PR DESCRIPTION
Just reorganizes the content to flow better

I don't think "at least one sub-discipline upon abstract registration" is clear to individuals, maybe we should list out the sub-disciplines?