### PR TITLE
Removes reference to ACM

### DIFF
--- a/templates/content/register.md
+++ b/templates/content/register.md
@@ -14,11 +14,11 @@ The 2022 Conference on Health, Inference, and Learning will be held online. Full
             <th>Amount (USD)</th>
         </tr>
         <tr>
-            <td>ACM Member</td>
+            <td>Student</td>
             <td>25</td>
         </tr>
         <tr>
-            <td>Non-ACM Member</td>
+            <td>Non-Student</td>
             <td>40</td>
         </tr>
     </tbody>


### PR DESCRIPTION
Fixes #107. Renames "ACM Member" -> "Student" and "Non-ACM Member" -> "Non-Student" to remove reference to ACM.

Please take a look and deploy after merging.