### PR TITLE
Adds a button for paper submissions to the homepage

### DIFF
--- a/templates/content/index.md
+++ b/templates/content/index.md
@@ -4,7 +4,7 @@ The Conference on Health, Inference, and Learning (CHIL), targets a cross-discip
 
 The conference is designed to spark insight-driven discussions on new and emerging ideas that may lead to collaboration and discussion.
 
-<br />
+<center><a class="btn btn-primary btn-lg active" role="button" aria-pressed="true" href="https://openreview.net/group?id=chilconference.org/CHIL/2022/Conference" target="_blank" rel="noopener">Submit your paper</a></center>
 
 <div class="hidden">
 ### Conference Timeline

--- a/templates/index.html
+++ b/templates/index.html
@@ -32,7 +32,7 @@
           <div class="wrapper hidden" id="countdown-flipper" data-is-active="false"></div>
           <!-- TODO: hack to add preregistration link on short notice -->
           <!-- <a class="btn-primary btn-lg" href="/2021/highlights.html">WATCH 2021 REPLAY!</a> -->
-          <a class="btn-primary btn-lg" href="https://forms.gle/o9UNVW9xSeeYafJu6">PREREGISTER TODAY!</a>
+          <a class="btn-primary btn-lg" href="https://forms.gle/o9UNVW9xSeeYafJu6">Pre-register today!</a>
         </div>
       </div>
     </div>


### PR DESCRIPTION
This adds a button for paper submissions to the homepage. The submit your paper button on the call for papers page remains as well. 