### PR TITLE
Remove hours and minutes from the countdown

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -164,7 +164,7 @@
 
           $(currentCountdownElement)
             .countdown(countDownDate, function(event) {
-              currentCountdownElement.html(event.strftime('%w weeks %d days %H:%M'));
+              currentCountdownElement.html(event.strftime('%w weeks %d days'));
             });
       });
     });


### PR DESCRIPTION
As discussed in https://github.com/ahli-org/chil-website/pull/124, currently the [schedule countdown](http://chilconference.org/) displays weeks, days, hours and minutes. @corcra if we want to remove hours and minutes, then I think this pull request should do it. Please check though! Something more sophisticated might be needed.

