### PR TITLE
Add sponsor logos to website pages

### DIFF
--- a/sitedata/sponsors.csv
+++ b/sitedata/sponsors.csv
@@ -1,6 +1,3 @@
 UID,name,image,level
-1,Google,/static/images/sponsors/google.png,silver
-2,Health@Scale,/static/images/sponsors/health-at-scale.png,silver
-3,Creative Destruction Lab,/static/images/sponsors/creative-destruction-lab.png,bronze
-4,Layer6,/static/images/sponsors/layer6-ai.png,bronze
-5,Vector Institute,/static/images/sponsors/vector-institute.png,bronze
+1,Health@Scale,/static/images/sponsors/health-at-scale.png,silver
+2,Vector Institute,/static/images/sponsors/vector-institute.png,silver

--- a/templates/base.html
+++ b/templates/base.html
@@ -49,8 +49,7 @@
     ('index.html', 'Home'),
     ('call-for-papers.html', 'Call for Papers'),
     ('register.html', 'Registration'),
-    ('program.html', 'Program'),
-    ('chat.html', 'Chat')
+    ('program.html', 'Program')
   ] -%}
 
   {# Removed navigation_bar ENTRIES
@@ -61,6 +60,7 @@
     ('workshops.html', 'Workshops')
     ('help.html', 'Help'),
     ('register.html', 'Registration'),
+    ('chat.html', 'Chat')
   #}
 
   {% set organization_dropdown_bar = [

--- a/templates/base.html
+++ b/templates/base.html
@@ -170,9 +170,8 @@
 
 {% block bottom %}
   <!-- Sponsors -->
-  <!-- TODO: This is being commented out to fix issue with 2021 sponsors on CFP page -->
   {% if sponsors %}
-    <<div class="container">
+    <div class="container">
       <br />
       <h3>{{config.page_title.prefix}} Sponsors</h3>
       <p>Thank you to our 2022 sponsors, Health[at]Scale and the Vector Institute!</p>

--- a/templates/base.html
+++ b/templates/base.html
@@ -49,7 +49,8 @@
     ('index.html', 'Home'),
     ('call-for-papers.html', 'Call for Papers'),
     ('register.html', 'Registration'),
-    ('program.html', 'Program')
+    ('program.html', 'Program'),
+    ('chat.html', 'Chat')
   ] -%}
 
   {# Removed navigation_bar ENTRIES
@@ -58,7 +59,6 @@
     ('live.html', 'Live'),
     ('papers.html', 'Papers'),
     ('workshops.html', 'Workshops')
-    ('chat.html', 'Chat'),
     ('help.html', 'Help'),
     ('register.html', 'Registration'),
   #}
@@ -172,12 +172,12 @@
   <!-- Sponsors -->
   <!-- TODO: This is being commented out to fix issue with 2021 sponsors on CFP page -->
   {% if sponsors %}
-    <!-- <div class="container">
+    <<div class="container">
       <br />
       <h3>{{config.page_title.prefix}} Sponsors</h3>
-      <p>We thank our <a href="/2021/highlights.html">sponsors</a> for making the CHIL 2021 conference a success.</p> -->
-      <!-- {{ components.sponsorgroup(sponsors) }} -->
-    <!-- </div> -->
+      <p>Thank you to our 2022 sponsors, Health[at]Scale and the Vector Institute!</p>
+      {{ components.sponsorgroup(sponsors) }}
+    </div>
   {% endif %}
 {% endblock %}
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -51,9 +51,6 @@
   </div>
 {% endblock %}
 
-{% block bottom %}
-{% endblock %}
-
 {% block scripts %}
   {{ super() }}
   <script src="https://cdn.jsdelivr.net/npm/jquery-countdown@2.2.0/dist/jquery.countdown.min.js"


### PR DESCRIPTION
This PR adds the 2022 sponsor logos to the footer of each page on the website.

closes #127 