### PR TITLE
Auth0 setup

### DIFF
--- a/sitedata/config.yml
+++ b/sitedata/config.yml
@@ -35,9 +35,10 @@ default_poster_pdf: /static/images/GLTR_poster.pdf
 #pass: mIniconf1_
 
 use_auth0: true
-auth0_client_id : 5XCCPprOntZj7tNzPelC4ARWQzpeSvC0
-auth0_domain : dev-2yyn93jp.us.auth0.com
-auth0_authorize_endpoint: https://acmchil.us.auth0.com/authorize
+auth0_client_id : idrCis50v8uMru0k189CZY3LXVK9tUnY
+auth0_domain : chil.us.auth0.com
+auth0_authorize_endpoint: 
+# https://acmchil.us.auth0.com/authorize
 
 calendar:
   colors: #  Colors for the different event hashtags:

--- a/sitedata/config.yml
+++ b/sitedata/config.yml
@@ -37,8 +37,7 @@ default_poster_pdf: /static/images/GLTR_poster.pdf
 use_auth0: true
 auth0_client_id : idrCis50v8uMru0k189CZY3LXVK9tUnY
 auth0_domain : chil.us.auth0.com
-auth0_authorize_endpoint: 
-# https://acmchil.us.auth0.com/authorize
+auth0_authorize_endpoint: https://chil.us.auth0.com/authorize
 
 calendar:
   colors: #  Colors for the different event hashtags:

--- a/sitedata/config.yml
+++ b/sitedata/config.yml
@@ -34,9 +34,9 @@ default_poster_pdf: /static/images/GLTR_poster.pdf
 #user: miniconf@miniconf.com
 #pass: mIniconf1_
 
-use_auth0: false
-auth0_client_id : xzIZGAdejTq7QGPYJdZiB9KCooW7aYK9
-auth0_domain : acmchil.us.auth0.com
+use_auth0: true
+auth0_client_id : 5XCCPprOntZj7tNzPelC4ARWQzpeSvC0
+auth0_domain : dev-2yyn93jp.us.auth0.com
 auth0_authorize_endpoint: https://acmchil.us.auth0.com/authorize
 
 calendar:

--- a/templates/base.html
+++ b/templates/base.html
@@ -47,6 +47,8 @@
 {% block header %}
   {% set navigation_bar = [
     ('index.html', 'Home'),
+    ('live.html', 'Live'),
+    ('chat.html', 'Chat'),
     ('call-for-papers.html', 'Call for Papers'),
     ('register.html', 'Registration'),
     ('program.html', 'Program')

--- a/templates/base.html
+++ b/templates/base.html
@@ -47,8 +47,6 @@
 {% block header %}
   {% set navigation_bar = [
     ('index.html', 'Home'),
-    ('live.html', 'Live'),
-    ('chat.html', 'Chat'),
     ('call-for-papers.html', 'Call for Papers'),
     ('register.html', 'Registration'),
     ('program.html', 'Program')


### PR DESCRIPTION
Adding auth0 information in the config.yml file; useful for us testing that out (+rocketchat) prior to enabling the "live" and "chat" tabs as part of the deployed website.