### PR TITLE
This corrects the breakout session times on day 1

### DIFF
--- a/sitedata/schedule.yml
+++ b/sitedata/schedule.yml
@@ -189,7 +189,7 @@ thursday:
     linktext: Gathertown
     linkactive: false
 
-  - time: "3:30 - 4:25 PM"
+  - time: "3:30 - 4:30 PM"
     type: Breakout
     title: "Responsible AI for health"
     speaker: Leo Celi
@@ -199,7 +199,7 @@ thursday:
     linktext: Gathertown
     linkactive: false
 
-  - time: "4:00 - 4:25 PM"
+  - time: "3:30 - 4:30 PM"
     type: Breakout
     title: "Social and environmental determinants of health"
     speaker: Esra Suel


### PR DESCRIPTION
This corrects the breakout session times for:

- Responsible AI for health
- Social and environmental determinants of health

The Schedule_CHIL 2022 Google Doc has also been updated so that these incorrect times won't get added back in on a future schedule update. Closes #142 . 