### PR TITLE
Add instructions for logging into RocketChat to the live page

### DIFF
--- a/templates/components.html
+++ b/templates/components.html
@@ -364,6 +364,8 @@ schedule
 {% macro rocketchat(rocketchat_id,chat_server) -%}
 {% if rocketchat_id %}
 {{ section("Chat") }}
+  <h6 align="left">To sign in to RocketChat, click the <b>Login via Auth0</b> button. You do not need to enter an email
+    and password. You will be asked to choose a chat nickname.</h6>
 <div class="col-md-12 col-xs-12 p-2">
   <div id="gitter" class="slp">
     <center>


### PR DESCRIPTION
This adds a note above the RocketChat iframe which instructs users to use the "Login via Auth0" button to log into RocketChat. 