### PR TITLE
Remove date from live page

### DIFF
--- a/templates/live.html
+++ b/templates/live.html
@@ -14,7 +14,7 @@
   </div>
   <div id="gated-content" class="page-content live text-center">
     <!-- Slides Live-->
-    {{ components.subsection("Day 1 - April 7th") }}
+    <!-- {{ components.subsection("Day 1 - April 7th") }} -->
     {{ components.slideslive(38979174) }}
 
     <!--


### PR DESCRIPTION
This removes the Day 1 + date from the live page so that it won't need to be updated after Day 1 for the start of Day 2. 