### PR TITLE
Prevent focus from shifting to embedded rocket.chat on the `live.html` page

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -290,6 +290,26 @@
       $('.dropdown-menu a.dropdown-toggle').click(ddHoverOrClick).hover(ddHoverOrClick).on('touchstart', ddHoverOrClick);
     });
   </script>
+
+  <!-- Prevent focus from jumping to embedded rocket.chat with an iframe id="chatFrame" -->
+  if ($("#chatFrame").val() != "") {
+    <script type="text/javascript">
+        $("#chatFrame").hide();
+        $("#chatFrame").on(
+          "load",
+          function() {
+            setTimeout(
+              function(){
+                $('#chatFrame').show();
+                $('#chatFrame').removeAttr('style');
+              },
+              3000
+            );
+          }
+        )
+    </script>
+  }
+
   <!-- <script src="/static/js/modules/lazyLoad.js"></script> -->
 {% endblock %}
 </body>

--- a/templates/components.html
+++ b/templates/components.html
@@ -373,7 +373,8 @@ schedule
 <div class="col-md-12 col-xs-12 p-2">
   <div id="gitter" class="slp">
     <center>
-      <iframe frameborder="0" src="https://{{chat_server}}/channel/{{rocketchat_id}}" height="650px" width="100%" ></iframe>
+      <iframe id="chatFrame" frameborder="0" src="https://{{chat_server}}/channel/{{rocketchat_id}}" height="650px"
+              width="100%" ></iframe>
     </center>
   </div>
 </div>


### PR DESCRIPTION
This adds jQuery code to prevent focus from jumping to the embedded rocket.chat iframe. Closes #73 .