### PR TITLE
add link to gather town to live page

### DIFF
--- a/templates/content/live.md
+++ b/templates/content/live.md
@@ -1,4 +1,5 @@
 <div class="gather-town">
     <img class="gather-town-avatar" src="/static/images/gather-avatar.png" alt="gather town avatar"/>
-    <p class="gather-town-text">Join us on GatherTown for lunch and poster sessions. See <a href="/calendar.html#tab-schedule" rel="noopener">schedule</a> for more details. </p>
+    <p class="gather-town-text">Join us in <a href="https://app.gather.town/app/j4TbOZN9zwDb9xsP/CHIL">GatherTown</a> for breakouts, sponsors, posters, and socialising.</p>
+    <!-- See <a href="/calendar.html#tab-schedule" rel="noopener">schedule</a> for more details. -->
 </div>


### PR DESCRIPTION
Adds the link to our current gather.town space to the bottom of the live page, and removes the "see schedule for details" bit (as I am not sure what details we are alluding to there).

Password will be communicated directly to registered attendees.