### PR TITLE
Add zoom links to live page

### DIFF
--- a/static/css/pages/live.css
+++ b/static/css/pages/live.css
@@ -4,27 +4,6 @@
   border: none;
 }
 
-.live .gather-town {
-  display: flex;
-  margin: 60px auto;
-  align-items: center;
-  justify-content: center;
-}
-
-.live .gather-town-avatar {
-  width: 144px;
-  height: 144px;
-  object-fit: cover;
-  object-position: 0px 0px;
-  image-rendering: pixelated;
-  margin-right: 10px;
-}
-
-.live .gather-town-text {
-  width: 283px;
-  font-size: 18px;
-}
-
 .live .table-tutorials {
   margin-bottom: 60px;
 }

--- a/templates/content/live.md
+++ b/templates/content/live.md
@@ -1,3 +1,8 @@
-<h6 align="left"><p>Tutorials are held in Zoom. Day 1 link <a href="https://us06web.zoom.us/j/81140384540">here</a>. Day 2 link <a href="https://us06web.zoom.us/j/81712359352">here</a>.</p>
-<p>Join us in <a href="https://app.gather.town/app/j4TbOZN9zwDb9xsP/CHIL">Gather</a> for breakouts, sponsors, posters, and socialising.</p>
-<img class="gather-town-avatar" src="/static/images/gather-avatar.png" alt="gather town avatar"/>
+<h6 align="left"><p>Go to <b>Zoom</b> for <b>Tutorials</b>. Day 1 link <a href="https://us06web.zoom.us/j/81140384540">here</a>. Day 2 link <a href="https://us06web.zoom.us/j/81712359352">here</a>.</p>
+<p>Go to <b><a href="https://app.gather.town/app/j4TbOZN9zwDb9xsP/CHIL">Gather</a></b> (<a href="https://app.gather.town/app/j4TbOZN9zwDb9xsP/CHIL">link</a>) for
+<ul>
+<li>Poster session</li>
+<li>Research roundtables</li>
+<li>Sponsor booths</li>
+<li>General socialising</lu>
+</ul>

--- a/templates/content/live.md
+++ b/templates/content/live.md
@@ -1,4 +1,2 @@
-<div class="gather-town">
-    <img class="gather-town-avatar" src="/static/images/gather-avatar.png" alt="gather town avatar"/>
-    <p class="gather-town-text">Join us on GatherTown for lunch and poster sessions. See <a href="/calendar.html#tab-schedule" rel="noopener">schedule</a> for more details. </p>
-</div>
+<h6 align="left"><p>Tutorials are held in Zoom. Day 1 link <a href="https://us06web.zoom.us/j/81140384540">here</a>. Day 2 link <a href="https://us06web.zoom.us/j/81712359352">here</a>.</p>
+<p>Join us on GatherTown for lunch and poster sessions. See <a href="/calendar.html#tab-schedule" rel="noopener">schedule</a> for more details.</p>

--- a/templates/content/live.md
+++ b/templates/content/live.md
@@ -1,5 +1,5 @@
-<h6 align="left"><p>Go to <b>Zoom</b> for <b>Tutorials</b>. Day 1 link <a href="https://us06web.zoom.us/j/81140384540">here</a>. Day 2 link <a href="https://us06web.zoom.us/j/81712359352">here</a>.</p>
-<p>Go to <b><a href="https://app.gather.town/app/j4TbOZN9zwDb9xsP/CHIL">Gather</a></b> (<a href="https://app.gather.town/app/j4TbOZN9zwDb9xsP/CHIL">link</a>) for
+<h6 align="left"><p>Tutorials are hosted in Zoom. For Day 1, the link can be found <a href="https://us06web.zoom.us/j/81140384540">here</a>. For Day 2, the link can be found <a href="https://us06web.zoom.us/j/81712359352">here</a>.</p>
+<p>Gather (<a href="https://app.gather.town/app/j4TbOZN9zwDb9xsP/CHIL">link</a>) is used for:
 <ul>
 <li>Poster session</li>
 <li>Research roundtables</li>

--- a/templates/live.html
+++ b/templates/live.html
@@ -12,7 +12,7 @@
   <div class="page-header text-center">
     <h1>CHIL Conference 2022</h1>
   </div>
-  <div id="gated-content" class="page-content live text-center">
+  <div id="gated-content" class="page-content live">
     <!-- Slides Live-->
     <!-- {{ components.subsection("Day 1 - April 7th") }} -->
     {{ components.slideslive(38979174) }}

--- a/templates/live.html
+++ b/templates/live.html
@@ -10,7 +10,7 @@
 
 {% block content %}
   <div class="page-header text-center">
-    <h1>CHIL Conference 2022</h1>
+    <h1>Livestream</h1>
   </div>
   <div id="gated-content" class="page-content live">
     <!-- Slides Live-->
@@ -29,6 +29,7 @@
     <!-- Rocket.Chat -->
     {{ components.rocketchat(config.default_chat_channel,config.chat_server) }}
 
+    {{ components.section("Useful links") }}
     {{ live | markdown }}
   </div>
 {% endblock %}


### PR DESCRIPTION
Adds the links to zoom tutorials for day 1 and day 2 to the live page. Does not include the passwords for said meetings.

I was fighting with the flexbox that the snowman and gather text were contained in, so I just removed it for simplicity. This section fo text now matches the rocket.chat instructions in aesthetics.