### PR TITLE
This fixes the rocket.chat focus script

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -292,23 +292,23 @@
   </script>
 
   <!-- Prevent focus from jumping to embedded rocket.chat with an iframe id="chatFrame" -->
-  if ($("#chatFrame").val() != "") {
-    <script type="text/javascript">
-        $("#chatFrame").hide();
-        $("#chatFrame").on(
-          "load",
-          function() {
-            setTimeout(
-              function(){
-                $('#chatFrame').show();
-                $('#chatFrame').removeAttr('style');
-              },
-              3000
-            );
-          }
-        )
-    </script>
-  }
+  <script type="text/javascript">
+    if ($("#chatFrame").length > 0) {
+          $("#chatFrame").hide();
+          $("#chatFrame").on(
+            "load",
+            function() {
+              setTimeout(
+                function(){
+                  $('#chatFrame').show();
+                  $('#chatFrame').removeAttr('style');
+                },
+                3000
+              );
+            }
+          )
+    }
+  </script>
 
   <!-- <script src="/static/js/modules/lazyLoad.js"></script> -->
 {% endblock %}


### PR DESCRIPTION
The `if` statement needed to be moved inside the `script` tag and it uses `.length` instead of `.val` since `.val` was not working to detect the iframe `id`. The original PR was #156 .  