### PR TITLE
Add links to the live page and remove navigation to Registration

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -47,10 +47,10 @@
 {% block header %}
   {% set navigation_bar = [
     ('index.html', 'Home'),
-    ('call-for-papers.html', 'Call for Papers'),
-    ('register.html', 'Registration'),
+    ('live.html', 'Livestream'),
     ('program.html', 'Program'),
     ('calendar.html', 'Schedule'),
+    ('call-for-papers.html', 'Call for Papers')
   ] -%}
 
   {# Removed navigation_bar ENTRIES

--- a/templates/content/call-for-papers-author-info.md
+++ b/templates/content/call-for-papers-author-info.md
@@ -4,8 +4,6 @@ To ensure that all submissions to CHIL are reviewed by a knowledgeable and appro
 
 Track Chairs will oversee the reviewing process. In case you are not sure which track your submission fits under, feel free to contact [info@chilconference.org](mailto:info@chilconference.org) for clarification. The Proceedings Chairs reserve the right to move submissions between tracks and/or topic areas if they believe that a submission has been misclassified.
 
-<center><a class="btn-primary btn-lg" role="button" aria-pressed="true" href="https://openreview.net/group?id=chilconference.org/CHIL/2022/Conference" target="_blank" rel="noopener">Submit your paper</a></center>
-
 ## Important Dates
 - Submissions Due – January 14, 2022 (11:59 pm AoE)
 - Author Notification - February 25, 2022

--- a/templates/index.html
+++ b/templates/index.html
@@ -32,7 +32,7 @@
           <div class="wrapper hidden" id="countdown-flipper" data-is-active="false"></div>
           <!-- TODO: hack to add preregistration link on short notice -->
           <!-- <a class="btn-primary btn-lg" href="/2021/highlights.html">WATCH 2021 REPLAY!</a> -->
-          <a class="btn-primary btn-lg" href="https://chil2022.eventbrite.com/">Register today!</a>
+          <a class="btn-primary btn-lg" href="/live.html">Watch the Livestream!</a>
         </div>
       </div>
     </div>


### PR DESCRIPTION
This PR should not be deployed to the website until registration closes. 

The PR adds Livestream links which point to `live.html`. It also removes the navigation bar tab for Registration. Lastly, it shifts the navigation bar tab for Call For Papers to the right, so the more relevant tabs are all to the left of the navigation bar. Closes #150 .