### PR TITLE
For schedule page, make Friday tab the default/active tab for day 2

### DIFF
--- a/templates/schedule.html
+++ b/templates/schedule.html
@@ -12,8 +12,8 @@
     <h1>Schedule</h1>
   </div>
   {{ components.tabs([
-        ("thursday", "Thursday, April 7", "active"),
-        ("friday", "Friday, April 8"),
+        ("thursday", "Thursday, April 7"),
+        ("friday", "Friday, April 8", "active"),
     ])}}
 {% endblock %}
 


### PR DESCRIPTION
This makes the Friday tab on the schedule page the default tab, as desired for day 2. 