### PR TITLE
Switching default schedule content to be Friday's

### DIFF
--- a/templates/schedule.html
+++ b/templates/schedule.html
@@ -25,7 +25,7 @@
 
       <!-- Thursday tab -->
       <div
-        class="tab-pane active"
+        class="tab-pane"
         id="tab-thursday"
         role="tabpanel"
         aria-labelledby="nav-profile-tab"
@@ -34,7 +34,7 @@
       </div>
       <!-- Friday tab -->
       <div
-        class="tab-pane"
+        class="tab-pane active"
         id="tab-friday"
         role="tabpanel"
         aria-labelledby="nav-profile-tab"


### PR DESCRIPTION
PR #167 changes the default tab but not the actual default schedule content; this PR fixes that issue.