### PR TITLE
Post-conference changes

### DIFF
--- a/templates/components.html
+++ b/templates/components.html
@@ -1,7 +1,7 @@
 {#
 Components:
 tabs -- Navigation tabs
-section, subsection, sm_section -- bootstrap sections
+section, subsection, livestream_subsection, sm_section -- bootstrap sections
 speakergroup
 organizergroup
 faqgroup
@@ -48,6 +48,14 @@ schedule
 <div class="row p-3">
   <div class="col-12 bd-content">
     <h3>{{name}}</h3>
+  </div>
+</div>
+{%- endmacro %}
+
+{% macro livestream_subsection(name) -%}
+<div class="row p-3">
+  <div class="col-12 bd-content">
+    <h3 class="text-center">{{name}}</h3>
   </div>
 </div>
 {%- endmacro %}

--- a/templates/live.html
+++ b/templates/live.html
@@ -14,11 +14,11 @@
   </div>
   <div id="gated-content" class="page-content live">
     <!-- Slides Live-->
-    <!-- {{ components.subsection("Day 1 - April 7th") }}
-    {{ components.slideslive(38979174) }} -->
+    {{ components.livestream_subsection("Day 1 - April 7th") }}
+    {{ components.slideslive(38979174) }}
 
 
-    <!--{{ components.subsection("Day 2 - April 8th") }}-->
+    {{ components.livestream_subsection("Day 2 - April 8th") }}
     {{ components.slideslive(38979175) }}
 
 

--- a/templates/schedule.html
+++ b/templates/schedule.html
@@ -12,8 +12,8 @@
     <h1>Schedule</h1>
   </div>
   {{ components.tabs([
-        ("thursday", "Thursday, April 7"),
-        ("friday", "Friday, April 8", "active"),
+        ("thursday", "Thursday, April 7", "active"),
+        ("friday", "Friday, April 8"),
     ])}}
 {% endblock %}
 
@@ -25,7 +25,7 @@
 
       <!-- Thursday tab -->
       <div
-        class="tab-pane"
+        class="tab-pane active"
         id="tab-thursday"
         role="tabpanel"
         aria-labelledby="nav-profile-tab"
@@ -34,7 +34,7 @@
       </div>
       <!-- Friday tab -->
       <div
-        class="tab-pane active"
+        class="tab-pane"
         id="tab-friday"
         role="tabpanel"
         aria-labelledby="nav-profile-tab"


### PR DESCRIPTION
- Introducing a block "livestream_subsection" to enable centering the title indicating the day of each stream
- Setting Thursday (day 1) as the default day of the schedule page