### PR TITLE
Updating for CFP extension to 2/15

### DIFF
--- a/templates/content/call-for-doctoral.md
+++ b/templates/content/call-for-doctoral.md
@@ -1,11 +1,11 @@
 The AHLI CHIL 2023 Doctoral Symposium is an opportunity for PhD students to broadcast their research and get feedback on their directions from CHIL attendees and leaders in the field. Participants will present their ongoing and/or future doctoral dissertation work as both a 5 minute lightning presentation and as a poster, encouraging cross-pollination of ideas with senior leaders and CHIL participants. In addition to the lightning talks and poster session, participants will have facilitated opportunities to connect with and meet established researchers one-on-one throughout the conference. The Doctoral Symposium will be held on June 24, 2023 in Cambridge, MA, United States.
 
 ### Important Dates
-- Application due: Feb 10, 2023 11:59 PM EST
-- Notification: April 5, 2023
+- Application due: <s>Feb 10, 2023 11:59 PM EST</s> Feb 17, 2023 11:59 PM EST
+- Notification: <s>April 5, 2023</s> April 10, 2023
 - Doctoral Symposium: June 24, 2023 (Cambridge, MA, USA)
 
 ### Application
-Please apply by filling out the application form at [https://forms.gle/XUTpasnkcLjGmpda6](https://forms.gle/XUTpasnkcLjGmpda6) by February 10, 2023.
+Please apply by filling out the application form at [https://forms.gle/XUTpasnkcLjGmpda6](https://forms.gle/XUTpasnkcLjGmpda6) by February 17, 2023.
 
 We welcome applications from Ph.D. students in computer science, data science, medical/health informatics, and other related fields. Successful candidates can be either senior students with concrete dissertations or junior students without full plans who may benefit from feedback from other participants.

--- a/templates/content/call-for-papers-author-info.md
+++ b/templates/content/call-for-papers-author-info.md
@@ -6,9 +6,9 @@ Track Chairs will oversee the reviewing process. In case you are not sure which 
 
 
 ### Important Dates
-- Submissions due: Feb 3rd, 11:59 EST
-- Author/Reviewer Discussion period: March 10th - March 24th
-- Author notification: April 3rd
+- Submissions due: <s>Feb 3rd, 11:59 EST</s> Feb 15th, 11:59 EST
+- Author/Reviewer Discussion period: <s>March 10th - March 24th</s> March 20th - April 3rd
+- Author notification: <s>April 3rd</s> April 10th
 - CHIL conference: June 22-24 
 
 <!-- **NOTE**: The submission portal will remain open until **January 18, 2022 (11:59 pm AoE)** for those who would like to make revisions to their submitted work. -->
@@ -64,7 +64,7 @@ At least one author of each accepted paper is required to register for, attend, 
 ### Length and Formatting
 Submitted papers must be 8-10 pages (including all figures and tables), plus unlimited pages for references. Additional supplementary materials (e.g., appendices) can be submitted with their main manuscript. Reviewers will not be required to read the supplementary materials.
 
-Authors are required to use the LaTeX template: [Download](https://drive.google.com/file/d/1EQc5RHHc5u7zdKhBCy1wIqwo0V0fGi-p/view?usp=sharing).
+Authors are required to use the LaTeX template: [Download](https://drive.google.com/file/d/1EQc5RHHc5u7zdKhBCy1wIqwo0V0fGi-p/view?usp=sharing) or [Overleaf](https://www.overleaf.com/latex/templates/chil-2023-template/yrwrrhnxsjwc).
 
 <!-- Authors are required to use the LaTeX template: [Overleaf](https://www.overleaf.com/latex/templates/chil-2022-template/jsypybzpbbdd) or [Download](https://chilconference.org/chil-template-2022.zip). -->
 

--- a/templates/content/call-for-papers-reviewer.md
+++ b/templates/content/call-for-papers-reviewer.md
@@ -10,33 +10,33 @@ Jump to: Timeline and Workload - [bidding](#bidding) - [assignment](#assignment)
 
 To deliver high-quality reviews, you (a CHIL reviewer) are expected to participate in the 4 distinct phases of review:
 
-- Bidding period (2/4 - 2/7)
+- <s> Bidding period (2/4 - 2/7)
 	- Skim abstracts and suggest >10 submissions you are interested in / qualified for
-	- Estimated time commitment: 1 hour or less
-- Assignment period (2/8 - 2/18)
+	- Estimated time commitment: 1 hour or less </s>
+- Assignment period <s>(2/8 - 2/18)</s> (2/16 - 2/17)
 	- Skim each of your assigned papers and report immediately
 		- Formatting violations
 		- Anonymity or Conflict of Interest violations 
 		- Topics you are not qualified to review
 	- Workload: 2-5 papers per reviewer
 	- Estimated time commitment: 10 minutes per paper
-- Review period (2/8 - 3/3)
+- Review period <s>(2/8 - 3/3)</s> (2/17 - 3/14)
 	- Deliver thoughtful review comments in timely fashion 
 	- Workload: 2-5 papers per reviewer
 	- Estimated time commitment: 2-5 hours per paper, spread out asynchronously
-- Discussion period (3/10 - 3/24)
+- Discussion period <s>(3/10 - 3/24)</s> (3/17 - 4/3)
 	- Provide comments that respond to author feedback, other reviewers, and chairs
 	- Workload: 2-5 papers per reviewer
 	- Estimated time commitment: 1-2 hours per paper, spread out asynchronously
 
 
-### <a name="bidding"></a>Bidding Period Instructions
+### <s><a name="bidding"></a>Bidding Period Instructions
 After all submissions are received on Feb. 3, you (a CHIL reviewer) will have the opportunity to review submitted titles/abstracts within OpenReview and indicate which papers you are most qualified for and excited about. Bidding instructions will be provided via email.
 
-Please bid promptly (by 2/7) and bid generously.
+Please bid promptly (by 2/7) and bid generously.</s>
 
 ### <a name="assignment"></a>Assignment Period Instructions
-By 2/7, you (a CHIL reviewer) will be formally assigned 2-5 papers to review for CHIL.
+By 2/17, you (a CHIL reviewer) will be formally assigned 2-5 papers to review for CHIL.
 We ask for each reviewer to promptly (within 10 days) skim their assigned papers to ensure:
 
 - no violations of required formatting rules (page limits, margins, etc)
@@ -46,7 +46,7 @@ We ask for each reviewer to promptly (within 10 days) skim their assigned papers
 If you feel that you cannot offer an informed opinion about the quality of the paper due to expertise mismatch, please write to your assigned Area Chair on OpenReview ASAP. Because of the diverse interests and finite availability of the research community, we cannot always reassign reviewers, but chairs will do our best to make sure each submission has the most competent reviewers available in the pool.
 
 ### <a name="reviewing"></a>Reviewing Period Instructions
-Between 2/8 and 3/3, you will be asked to complete thoughtful, constructive reviews for all assigned papers. Please make sure to complete your reviews by March 3rd, 11:59 EST (earlier preferred) For each paper, you’ll fill out a form on OpenReview, similar to the form below:
+Between 2/17 and 3/14, you will be asked to complete thoughtful, constructive reviews for all assigned papers. Please make sure to complete your reviews by March 14th, 11:59 EST (earlier preferred). For each paper, you’ll fill out a form on OpenReview, similar to the form below:
 
 #### Review format
 1. Summary of the paper
@@ -70,7 +70,7 @@ Between 2/8 and 3/3, you will be asked to complete thoughtful, constructive revi
 
 
 #### Emergency Reviewing
-To accommodate last minute emergencies, we will be seeking emergency reviewers for papers who do not receive all reviews by the deadline. Emergency reviewers will be sent a maximum of 3 papers by 3/5, and will need to write their reviews in a short time frame (between 3/5 and 3/8). Emergency review signup will be indicated in the reviewer signup form.
+To accommodate last minute emergencies, we will be seeking emergency reviewers for papers who do not receive all reviews by the deadline. Emergency reviewers will be sent a maximum of 3 papers by 3/15, and will need to write their reviews in a short time frame (between 3/15 and 3/18). Emergency review signup will be indicated in the reviewer signup form.
 
 #### General Advice for preparing reviews
 Follow the golden rule: be on time, provide polite and constructive reviews that you yourself would be happy to receive as an author. Be sure to review the paper, not the authors. When making statements about the paper, use phrases like “the paper proposes” rather than “the authors propose”. This makes your review less personal and separates critiques of the submission from critiques of the authors.
@@ -93,8 +93,8 @@ If you are a junior reviewer, there is no harm in asking a senior mentor or coll
 
 
 ### <a name="discussion"></a>Discussion and Consensus-Building Period Instructions
-Between 3/10 and 3/24, you (a CHIL reviewer) will be expected to participate in discussions on OpenReview by reading the authors’ response and comments from other reviewers, adding additional comments from your perspective, and updating your review accordingly. 
+Between 3/20 and 4/3, you (a CHIL reviewer) will be expected to participate in discussions on OpenReview by reading the authors’ response and comments from other reviewers, adding additional comments from your perspective, and updating your review accordingly. 
 
 We expect brief but thoughtful engagement from all reviewers here. For some papers, this would involve several iterations of feedback-response. A simplistic response of “I have read the authors’ response and I chose to keep my score unchanged” is not sufficient, because it does not provide detailed reasoning about what weaknesses are still salient and why the response is not sufficient. Please engage meaningfully!
 
-Track Chairs will work with reviewers to try to reach a consensus decision about each paper by 3/24. In the event that consensus is not reached, Track Chairs make final decisions about acceptance.
+Track Chairs will work with reviewers to try to reach a consensus decision about each paper by 4/3. In the event that consensus is not reached, Track Chairs make final decisions about acceptance.

--- a/templates/content/index.md
+++ b/templates/content/index.md
@@ -14,36 +14,46 @@ The conference is designed to spark insight-driven discussions on new and emergi
   <tbody>
     <tr>
       <th scope="row">Paper Submission Deadline</th>
-      <td>Feb 3, 2023</td>
-      <td class="text-right"><span class="countdown" data-startdate="2023-02-04T04:59:00.00Z"></span></td> 
+      <td>Feb 15, 2023</td>
+      <td class="text-right"><span class="countdown" data-startdate="2023-02-16T04:59:00.00Z"></span></td> 
     </tr>
     <tr>
       <th scope="row">Doctoral Symposium Deadline</th>
-      <td>Feb 10, 2023</td>
-      <td class="text-right"><span class="countdown" data-startdate="2023-02-11T04:59:00.00Z"></span></td> 
+      <td>Feb 18, 2023</td>
+      <td class="text-right"><span class="countdown" data-startdate="2023-02-18T04:59:00.00Z"></span></td> 
+    </tr>
+    <tr>
+      <th scope="row">Lightning Talk Deadline</th>
+      <td>Feb 28, 2023</td>
+      <td class="text-right"><span class="countdown" data-startdate="2023-03-01T04:59:00.00Z"></span></td> 
     </tr>
     <tr>
       <th scope="row">Paper Reviews Out / Author Response Begins</th>
-      <td>March 10, 2023</td>
-      <td class="text-right"><span class="countdown" data-startdate="2023-03-11T04:59:00.00Z"></span></td>
+      <td>March 20, 2023</td>
+      <td class="text-right"><span class="countdown" data-startdate="2023-03-21T04:59:00.00Z"></span></td>
     </tr>
     <tr>
       <th scope="row">Author Response Ends</th>
-      <td>March 24, 2023</td>
-      <td class="text-right"><span class="countdown" data-startdate="2023-03-25T03:59:00.00Z"></span></td>
-    </tr>
-    <tr>
-      <th scope="row">Paper Notifications Out</th>
       <td>April 3, 2023</td>
       <td class="text-right"><span class="countdown" data-startdate="2023-04-04T03:59:00.00Z"></span></td>
     </tr>
     <tr>
-      <th scope="row">Doctoral Symposium Notifications Out</th>
-      <td>April 5, 2023</td>
-      <td class="text-right"><span class="countdown" data-startdate="2023-04-06T03:59:00.00Z"></span></td> 
+      <th scope="row">Paper Notifications Out</th>
+      <td>April 10, 2023</td>
+      <td class="text-right"><span class="countdown" data-startdate="2023-04-11T03:59:00.00Z"></span></td>
     </tr>
     <tr>
-      <th scope="row">Conference dates</th>
+      <th scope="row">Doctoral Symposium Notifications Out</th>
+      <td>April 10, 2023</td>
+      <td class="text-right"><span class="countdown" data-startdate="2023-04-11T03:59:00.00Z"></span></td> 
+    </tr>
+    <tr>
+      <th scope="row">Lightning Talk Notifications Out</th>
+      <td>April 10, 2023</td>
+      <td class="text-right"><span class="countdown" data-startdate="2023-04-11T03:59:00.00Z"></span></td> 
+    </tr>
+    <tr>
+      <th scope="row">Conference Dates</th>
       <td>June 22-24, 2023</td>
       <td class="text-right"><span class="countdown" data-startdate="June 22, 2023"></span></td>
     </tr>


### PR DESCRIPTION
Modifying dates on landing page, doctoral symposium, and author+reviewer pages for the next timeline.