### PR TITLE
Add two new 2024 sponsors

### DIFF
--- a/sitedata/sponsors.csv
+++ b/sitedata/sponsors.csv
@@ -4,4 +4,6 @@ S02,UFlorida CTSI Department of Biomedical Informatics,static/images/sponsors/CT
 S03,Apple,static/images/sponsors/apple-logo.jpg,silver,
 S04,The Mount Sinai Hospital,static/images/sponsors/mount-sinai.png,silver,
 S05,University of Florida Health,static/images/sponsors/uflorida-health.gif,silver,
+S06,Chase Center at University of Pennsylvania, static/images/sponsors/UPenn-Chase-Center-logo.png,silver,
 S07,Columbia University (Biostats Dept.),static/images/sponsors/Columbia-logo.png,bronze,
+S08,Health Data Science,static/images/sponsors/Health-Data-Science-logo.jpg,bronze,

--- a/templates/base.html
+++ b/templates/base.html
@@ -225,7 +225,7 @@
     <div class="container">
       <br />
       <h3>{{config.page_title.prefix}} Sponsors</h3>
-      <p>Thank you to our 2024 sponsors: Gordon and Betty Moore Foundation (Gold), Department of Health Outcomes and Biomedical Informatics at UFlorida College of Medicine (Gold), Apple (Silver), The Mount Sinai Hospital (Silver), UF Health (Silver), Department of Biostatistics at University of Pennsylvania (Silver), and Department of Biostatistics at Columbia University (Bronze)!</p>
+      <p>Thank you to our 2024 sponsors: Gordon and Betty Moore Foundation (Gold), Department of Health Outcomes and Biomedical Informatics at UFlorida College of Medicine (Gold), Apple (Silver), The Mount Sinai Hospital (Silver), UF Health (Silver), Chase Center at University of Pennsylvania (Silver), Department of Biostatistics at University of Pennsylvania (Silver), Department of Biostatistics at Columbia University (Bronze), and Health Data Science (Brozne)!</p>
       {{ components.sponsorgroup(sponsors) }}
     </div>
   {% endif %}


### PR DESCRIPTION
This adds sponsor information to the website for the Chase Center at UPenn and Health Data Science. 