### PR TITLE
Add buttons and links for paper submissions

### DIFF
--- a/templates/call-for-papers.html
+++ b/templates/call-for-papers.html
@@ -27,6 +27,9 @@
         role="tabpanel"
         aria-labelledby="nav-profile-tab"
       >
+        <div class="text-center mt-4 mb-5">
+          <a class="btn-success btn-lg" href="https://openreview.net/group?id=chilconference.org/CHIL/2024/Conference#tab-recent-activity">Submit Your Paper</a>
+        </div>
         {{ call_for_papers_author_info | markdown }}
       </div>
       <!-- reviewer instructions -->

--- a/templates/content/call-for-papers-author-info.md
+++ b/templates/content/call-for-papers-author-info.md
@@ -60,7 +60,7 @@ An exception to this rule is extensions of workshop papers that have previously 
 
 ## Submission Format and Guidelines
 ### Submission Site
-Submissions should be made via the online submission system (**Coming soon!**). At least one author of each accepted paper is required to register for, attend, and present the work at the conference in order for the paper to appear in the conference proceedings.
+Submissions should be made via the online submission system: [https://openreview.net/group?id=chilconference.org/CHIL/2024/Conference#tab-recent-activity](https://openreview.net/group?id=chilconference.org/CHIL/2024/Conference#tab-recent-activity). At least one author of each accepted paper is required to register for, attend, and present the work at the conference in order for the paper to appear in the conference proceedings.
 
 <!-- Submissions should be made via the online submission system: [https://openreview.net/group?id=chilconference.org/CHIL/2022/Conference](https://openreview.net/group?id=chilconference.org/CHIL/2022/Conference). -->
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -31,8 +31,13 @@
         <div class="countdown-flipper">
           <div class="wrapper hidden" id="countdown-flipper" data-is-active="false"></div>
           <!-- TODO: hack to add preregistration link on short notice -->
-          <a class="btn-primary btn-lg" href="https://forms.gle/prNXAbU9z4BRZeyZA">Pre-register for CHIL 2024!</a>
-          <!--<a class="btn-primary btn-lg" href="/live.html">Watch the Livestream!</a> -->
+          <div class="mb-5">
+            <a class="btn-primary btn-lg" href="https://forms.gle/prNXAbU9z4BRZeyZA">Pre-register for CHIL 2024</a>
+          </div>
+          <div class="mb-5">
+            <a class="btn-success btn-lg" href="https://openreview.net/group?id=chilconference.org/CHIL/2024/Conference#tab-recent-activity">Submit Your Paper</a>
+          </div>
+            <!--<a class="btn-primary btn-lg" href="/live.html">Watch the Livestream!</a> -->
         </div>
       </div>
     </div>


### PR DESCRIPTION
This PR adds a button to the homepage and at the top of the "call for papers" page for paper submissions. It also adds a link to the text further below on the "call for papers" page. 