### PR TITLE
Remove April dates

### DIFF
--- a/archive/sitedata/2021/highlights.md
+++ b/archive/sitedata/2021/highlights.md
@@ -2,7 +2,7 @@
 <!-- Slides Live-->
 <div class="row p-3">
     <div class="col-12 bd-content">
-    <h3>Day 1 - April 8th</h3>
+    <h3>Day 1</h3>
     </div>
 </div>
 <div id="slideslive-embed" class="col-md-12 col-xs-12 my-auto p-2 hide" data-activedate="2021-04-14T23:59:00.00">
@@ -19,7 +19,7 @@
 </div>
 <div class="row p-3">
     <div class="col-12 bd-content">
-    <h3>Day 2 - April 9th</h3>
+    <h3>Day 2 </h3>
     </div>
 </div>
 <div id="slideslive-embed2" class="col-md-12 col-xs-12 my-auto p-2 hide" data-activedate="2021-04-14T23:59:00.00">

--- a/archive/sitedata/2022/highlights.md
+++ b/archive/sitedata/2022/highlights.md
@@ -2,7 +2,7 @@
 <!-- Slides Live-->
 <div class="row p-3">
     <div class="col-12 bd-content">
-    <h3>Day 1 - April 7th</h3>
+    <h3>Day 1</h3>
     </div>
 </div>
 <div id="slideslive-embed" class="col-md-12 col-xs-12 my-auto p-2 hide" data-activedate="2021-04-14T23:59:00.00">
@@ -19,7 +19,7 @@
 </div>
 <div class="row p-3">
     <div class="col-12 bd-content">
-    <h3>Day 2 - April 8th</h3>
+    <h3>Day 2</h3>
     </div>
 </div>
 <div id="slideslive-embed2" class="col-md-12 col-xs-12 my-auto p-2 hide" data-activedate="2021-04-14T23:59:00.00">

--- a/templates/content/call-for-papers.md
+++ b/templates/content/call-for-papers.md
@@ -13,7 +13,7 @@ _Note that although ACM CHIL 2020 was held in July, the CFP timelines targeted a
 - Submissions due – January 13, 2020 (11:59 pm AoE)
 - Notification of Acceptance – Feb 12, 2020 (11:59 pm AoE)
 - Camera Ready Due – March 6, 2020 (11:59 pm AoE)
-- (Original) Conference Date – April 2-4, 2020
+- (Original) Conference Date –  2020
 
 #### Tracks
 

--- a/templates/live.html
+++ b/templates/live.html
@@ -14,11 +14,11 @@
   </div>
   <div id="gated-content" class="page-content live">
     <!-- Slides Live-->
-    {{ components.livestream_subsection("Day 1 - April 7th") }}
+    {{ components.livestream_subsection("Day 1") }}
     {{ components.slideslive(38979174) }}
 
 
-    {{ components.livestream_subsection("Day 2 - April 8th") }}
+    {{ components.livestream_subsection("Day 2") }}
     {{ components.slideslive(38979175) }}
 
 

--- a/templates/program.html
+++ b/templates/program.html
@@ -123,7 +123,7 @@
         aria-labelledby="nav-profile-tab"
       >
         {% if workshops %}
-          {{ components.section("Thursday, April 8th, 4:30pm - 6:00pm - Poster Session A (Workshop)") }}
+          {{ components.section("Thursday, 4:30pm - 6:00pm - Poster Session A (Workshop)") }}
           {{ components.workshopgroup(workshops) }}
         {% endif %}
       </div>
@@ -135,7 +135,7 @@
         aria-labelledby="nav-profile-tab"
       >
         {% if proceedings %}
-          {{ components.section("Friday, April 9th, 2:15pm - 3:10pm - Poster Session B (Proceedings)") }}
+          {{ components.section("Friday, 2:15pm - 3:10pm - Poster Session B (Proceedings)") }}
           {{ components.workshopgroup(proceedings, 'proceeding') }}
         {% endif %}
       </div>


### PR DESCRIPTION
This removes some old April dates on the website. A post to LinkedIn scraped the websites and indicates that the June 2024 conference is on April 7th - 8th, 2022. 